### PR TITLE
Add meeting summary and task sections

### DIFF
--- a/app/components/MeetingSummary.tsx
+++ b/app/components/MeetingSummary.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { summary } from "../data/meeting";
+
+const MeetingSummary = () => (
+  <div>
+    <h2 className="text-2xl font-semibold mb-4">Toplantı Özeti</h2>
+    <p className="mb-4 text-sm text-gray-300">{summary.general}</p>
+
+    <h3 className="text-xl font-semibold mt-6 mb-2">Toplantının Amacı</h3>
+    <p className="mb-4 text-sm text-gray-300">{summary.purpose}</p>
+
+    <h3 className="text-xl font-semibold mt-6 mb-2">Ana Başlıklar</h3>
+    <ul className="list-disc list-inside text-sm text-gray-300">
+      {summary.mainTopics.map((t) => (
+        <li key={t}>{t}</li>
+      ))}
+    </ul>
+
+    <h3 className="text-xl font-semibold mt-6 mb-2">Alınan Kararlar</h3>
+    <p className="text-sm text-gray-300">{summary.decisions}</p>
+  </div>
+);
+
+export default MeetingSummary;

--- a/app/components/TasksList.tsx
+++ b/app/components/TasksList.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { tasks, mood, nextSteps } from "../data/meeting";
+
+const TasksList = () => (
+  <div>
+    <h2 className="text-2xl font-semibold mb-4">Görevler</h2>
+    <table className="w-full text-sm text-left text-gray-300 mb-6">
+      <thead className="text-xs uppercase text-gray-400 border-b border-gray-600">
+        <tr>
+          <th scope="col" className="py-2 px-3">Kişi</th>
+          <th scope="col" className="py-2 px-3">Görev</th>
+          <th scope="col" className="py-2 px-3">Tarih</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tasks.map((t) => (
+          <tr key={t.person} className="border-b border-gray-700">
+            <td className="py-2 px-3 font-medium whitespace-nowrap">{t.person}</td>
+            <td className="py-2 px-3">{t.task}</td>
+            <td className="py-2 px-3 whitespace-nowrap">{t.due}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+
+    <h3 className="text-xl font-semibold mt-4 mb-2">Duygu Durumu</h3>
+    <ul className="list-disc list-inside text-sm text-gray-300">
+      <li><b>Pozitif:</b> {mood.positive}</li>
+      <li><b>Negatif:</b> {mood.negative}</li>
+      <li><b>Belirsiz:</b> {mood.uncertain}</li>
+    </ul>
+
+    <h3 className="text-xl font-semibold mt-6 mb-2">Sonraki Adımlar</h3>
+    <p className="text-sm text-gray-300 mb-2"><b>En önemli iş:</b> {nextSteps.important}</p>
+    <ul className="list-disc list-inside text-sm text-gray-300">
+      {nextSteps.followUp.map((f) => (
+        <li key={f}>{f}</li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default TasksList;

--- a/app/components/TopicsNotes.tsx
+++ b/app/components/TopicsNotes.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { topics } from "../data/meeting";
+
+const TopicsNotes = () => (
+  <div>
+    <h2 className="text-2xl font-semibold mb-4">Konular ve Notlar</h2>
+    <div className="space-y-4">
+      {topics.map(({ title, notes }) => (
+        <div key={title}>
+          <h4 className="text-lg font-semibold mb-1">{title}</h4>
+          <ul className="list-disc list-inside text-sm text-gray-300">
+            {notes.map((n) => (
+              <li key={n}>{n}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default TopicsNotes;

--- a/app/data/meeting.ts
+++ b/app/data/meeting.ts
@@ -1,0 +1,71 @@
+export const summary = {
+  general: "Toplantı, Burhan Ok'un Otokent ile ilgili sunumunun devamı üzerine odaklanmıştır. Ayrıca Axess dokunmatik ekranın yenilenmesi (refresh) ve Euro projeksiyonların tamamlanması gibi konular da ele alınmıştır. Selin Üzeyiroğlu, Çıkamıyorum promosyonu ve Emre Dursun'un düzenleyeceği grafiklere bakma görevleri belirtmiştir. Sosyal medya testleri, Sefalet testi ve dashfordlar üzerinde de çalışmalar yapılacaktır.",
+  purpose: "Otokent sunumunun tamamlanması, Axess dokunmatik ekranın yenilenmesi, Euro projeksiyonların ilerletilmesi ve sosyal medya ile ilgili görevlerin dağıtılması.",
+  mainTopics: [
+    "Otokent Sunumu",
+    "Axess Dokunmatik Ekran Yenileme",
+    "Euro Projeksiyonlar",
+    "Sosyal Medya Testleri",
+    "Sefalet Testi",
+    "Dashfordlar",
+  ],
+  decisions: "Belirli bir karar alınmamıştır; daha çok görev dağıtımı ve yapılacak işlerin planlanması yapılmıştır.",
+};
+
+export const topics = [
+  {
+    title: "Otokent Sunumu",
+    notes: [
+      "Burhan Ok, Otokent ile ilgili sunumunu tamamlamaya çalışıyor. Video kısmını bitirdikten sonra diğer bölümlere geçecek.",
+      "Sosyal medya tarafında destek gerekirse Burhan Ok bakacak.",
+    ],
+  },
+  {
+    title: "Axess Dokunmatik Ekran Yenileme (Refresh)",
+    notes: [
+      "Axess dokunmatik ekranın yenilenmesi gerekmektedir.",
+      "Bu işlem genellikle uzun sürmekteymiş.",
+    ],
+  },
+  {
+    title: "Euro Projeksiyonlar",
+    notes: [
+      "Selin Üzeyiroğlu, bugün bir Euro projeksiyonu daha bitirmeyi planlıyor.",
+      "Daha sonra Çıkamıyorum promosyonu ve Emre Dursun'un düzenleyeceği grafiklere bakacak.",
+    ],
+  },
+  {
+    title: "Sosyal Medya Testleri",
+    notes: [
+      "Siz, Burhan Ok'tan sosyal medya ile ilgili isteklerde bulunacak ve testlerini yapacaktır.",
+      "Hilmi Tunahan Ahlatçı da sabah Sefalet testi yapıp öğleden sonra sosyal medya uygulamasına bakacak.",
+    ],
+  },
+  { title: "Sefalet Testi", notes: ["Hilmi Tunahan Ahlatçı, sabah saatlerinde Sefalet testini yapacak."] },
+  { title: "Dashfordlar", notes: ["Emre Dursun, dashfordları sahiplenecek ve üzerinde çalışacaktır."] },
+];
+
+export const tasks = [
+  { person: "Burhan Ok", task: "Otokent sunumunu tamamlamak", due: "Bugün" },
+  { person: "Selin Üzeyiroğlu", task: "Euro projeksiyonu bitirmek, Çıkamıyorum promosyonuna bakmak, Emre'nin düzenleyeceği grafiklere göz atmak", due: "Bugün" },
+  { person: "Siz", task: "Sosyal medya testlerini yapmak", due: "Bugün" },
+  { person: "Hilmi Tunahan Ahlatçı", task: "Sefalet testi yapmak, sosyal medya uygulamasına bakmak", due: "Bugün" },
+  { person: "Emre Dursun", task: "Axess dokunmatik ekran yenileme (refresh), dashfordlar üzerinde çalışmak", due: "Belirlenen süre içinde" },
+];
+
+export const mood = {
+  positive: "Çalışma planlaması yapılmış, görevler dağıtılmış ve herkesin bir hedefi var. \"Kolay gelsin\" dileği ile olumlu bir atmosfer sağlanmış.",
+  negative: "Axess dokunmatik ekran yenileme işleminin uzun süreceği belirtilmiş, bu da potansiyel bir gecikmeye işaret ediyor olabilir.",
+  uncertain: "Sosyal medya tarafında destek gerekiyorsa kimin bakacağı henüz netleşmemiş.",
+};
+
+export const nextSteps = {
+  followUp: [
+    "Otokent sunumunun tamamlanması",
+    "Axess dokunmatik ekran yenileme işleminin ilerleyişi",
+    "Euro projeksiyonların durumu",
+    "Sosyal medya testlerinin sonuçları",
+    "Dashfordlar üzerindeki çalışmalar",
+  ],
+  important: "Otokent sunumunu tamamlamak ve Axess dokunmatik ekran yenileme işlemini başlatmak.",
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,9 @@ import EmotionsRadarChart from "./components/EmotionsRadarChart";
 import CorrelationHeatmap from "./components/CorrelationHeatmap";
 import ParticipantActivityTimeline from "./components/ParticipantActivityTimeline";
 import EmotionTimelineAreaChart from "./components/EmotionTimelineAreaChart";
+import MeetingSummary from "./components/MeetingSummary";
+import TasksList from "./components/TasksList";
+import TopicsNotes from "./components/TopicsNotes";
 
 // --- ANA DASHBOARD BILEŞENİ ---
 const App = () => {
@@ -28,6 +31,21 @@ const App = () => {
 
       {/* Main Grid */}
       <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Özet */}
+        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+          <MeetingSummary />
+        </div>
+
+        {/* Görevler */}
+        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+          <TasksList />
+        </div>
+
+        {/* Konular ve Notlar */}
+        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+          <TopicsNotes />
+        </div>
+
         {/* 1. Satır: Shouting Chart (tam genişlik) */}
         <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
           <ShoutingChart />


### PR DESCRIPTION
## Summary
- include new meeting summary, task list and topic notes
- display these sections before the existing charts

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688caccea0bc8324a24ca4a3e87c6aa1