### PR TITLE
Add sidebar with meeting info

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import MeetingSummary from "./MeetingSummary";
+import TasksList from "./TasksList";
+import TopicsNotes from "./TopicsNotes";
+
+const meetings = ["Toplantı 1", "Toplantı 2", "Toplantı 3"];
+
+const Sidebar = () => (
+  <aside className="bg-[#171717] w-80 flex flex-col h-screen">
+    <div className="p-4 overflow-y-auto flex-1">
+      <h2 className="text-xl font-semibold mb-2">Toplantılar</h2>
+      <ul className="mb-6 space-y-1">
+        {meetings.map((m) => (
+          <li key={m} className="cursor-pointer hover:underline text-sm">
+            {m}
+          </li>
+        ))}
+      </ul>
+      <MeetingSummary />
+      <div className="mt-6">
+        <TasksList />
+      </div>
+      <div className="mt-6">
+        <TopicsNotes />
+      </div>
+    </div>
+    <div className="p-4 border-t border-gray-700 text-sm">
+      <p className="mb-2">Kullanıcı: Demo User</p>
+      <button className="w-full py-2 bg-red-600 rounded">Logout</button>
+    </div>
+  </aside>
+);
+
+export default Sidebar;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,9 +7,7 @@ import EmotionsRadarChart from "./components/EmotionsRadarChart";
 import CorrelationHeatmap from "./components/CorrelationHeatmap";
 import ParticipantActivityTimeline from "./components/ParticipantActivityTimeline";
 import EmotionTimelineAreaChart from "./components/EmotionTimelineAreaChart";
-import MeetingSummary from "./components/MeetingSummary";
-import TasksList from "./components/TasksList";
-import TopicsNotes from "./components/TopicsNotes";
+import Sidebar from "./components/Sidebar";
 
 // --- ANA DASHBOARD BILEŞENİ ---
 const App = () => {
@@ -22,34 +20,21 @@ const App = () => {
   if (!isClient) return null;
 
   return (
-    <div className="bg-[#0a0a0a] text-[#ededed] min-h-screen p-4 sm:p-8 font-sans">
-      {/* Header */}
-      <header className="text-center mb-10">
-        <h1 className="text-4xl font-bold tracking-tight">Toplantı Analiz Raporu</h1>
-        <p className="text-lg text-gray-400 mt-2">Toplantı metriklerinin görselleştirilmiş analizi</p>
-      </header>
+    <div className="bg-[#0a0a0a] text-[#ededed] min-h-screen flex font-sans">
+      <Sidebar />
+      <div className="flex-1 p-4 sm:p-8 overflow-y-auto">
+        {/* Header */}
+        <header className="text-center mb-10">
+          <h1 className="text-4xl font-bold tracking-tight">Toplantı Analiz Raporu</h1>
+          <p className="text-lg text-gray-400 mt-2">Toplantı metriklerinin görselleştirilmiş analizi</p>
+        </header>
 
-      {/* Main Grid */}
-      <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* Özet */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
-          <MeetingSummary />
-        </div>
-
-        {/* Görevler */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
-          <TasksList />
-        </div>
-
-        {/* Konular ve Notlar */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
-          <TopicsNotes />
-        </div>
-
-        {/* 1. Satır: Shouting Chart (tam genişlik) */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
-          <ShoutingChart />
-        </div>
+        {/* Main Grid */}
+        <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* 1. Satır: Shouting Chart (tam genişlik) */}
+          <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+            <ShoutingChart />
+          </div>
 
         {/* 2. Satır: Participant Activity Timeline (tam genişlik) */}
         <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
@@ -79,6 +64,7 @@ const App = () => {
       <footer className="text-center mt-12 text-gray-500">
         <p>&copy; {new Date().getFullYear()} Meeting Analysis Bot. Tüm hakları saklıdır.</p>
       </footer>
+    </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create a new `Sidebar` component
- restructure `page.tsx` to use the sidebar and move summary sections there

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cb1720e0c832498894f2bd4c6ec3e