### PR TITLE
Add simple auth check and modern sidebar

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,33 +1,81 @@
 "use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import MeetingSummary from "./MeetingSummary";
 import TasksList from "./TasksList";
 import TopicsNotes from "./TopicsNotes";
 
-const meetings = ["Toplantı 1", "Toplantı 2", "Toplantı 3"];
+const meetings = [
+  "Toplantı 1 - Pazarlama",
+  "Toplantı 2 - Ürün Geliştirme",
+  "Toplantı 3 - Sprint Planlama",
+  "Toplantı 4 - Retrospektif",
+  "Toplantı 5 - Q&A",
+];
 
-const Sidebar = () => (
-  <aside className="bg-white w-[30rem] fixed top-0 bottom-0 left-0 flex flex-col shadow-lg border-r border-gray-200">
-    <div className="p-6 overflow-y-auto flex-1 space-y-6">
-      <div>
-        <h2 className="text-xl font-semibold mb-3">Toplantılar</h2>
-        <ul className="space-y-2 text-sm">
-        {meetings.map((m) => (
-          <li key={m} className="cursor-pointer hover:underline">
-            {m}
-          </li>
-        ))}
-        </ul>
+const Sidebar = () => {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<string | null>(meetings[0]);
+
+  const filtered = meetings.filter((m) =>
+    m.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const handleLogout = () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("isAuthenticated");
+    }
+    router.push("/login");
+  };
+
+  return (
+    <aside className="bg-white w-[30rem] fixed top-0 bottom-0 left-0 flex flex-col shadow-lg border-r border-gray-200">
+      <div className="p-6 overflow-y-auto flex-1 space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold mb-3">Toplantılar</h2>
+          <input
+            type="text"
+            placeholder="Toplantı ara..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="mb-3 w-full border px-3 py-2 rounded"
+          />
+          <ul className="space-y-2 text-sm max-h-40 overflow-y-auto">
+            {filtered.map((m) => (
+              <li
+                key={m}
+                onClick={() => setSelected(m)}
+                className={`cursor-pointer p-2 rounded hover:bg-gray-100 ${
+                  selected === m ? "bg-gray-200 font-medium" : ""
+                }`}
+              >
+                {m}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-4">
+            <h3 className="text-sm font-semibold mb-1">Son Toplantılar</h3>
+            <ul className="text-xs text-gray-600 space-y-1">
+              {meetings.slice(0, 3).map((m) => (
+                <li key={`recent-${m}`}>{m}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <MeetingSummary />
+        <TasksList />
+        <TopicsNotes />
       </div>
-      <MeetingSummary />
-      <TasksList />
-      <TopicsNotes />
-    </div>
-    <div className="p-6 border-t border-gray-200 text-sm flex items-center space-x-3">
-      <img src="/favicon.ico" alt="User" className="w-8 h-8 rounded-full" />
-      <span className="flex-1">Demo User</span>
-      <button className="py-1 px-3 bg-red-500 text-white rounded">Çıkış Yap</button>
-    </div>
-  </aside>
-);
+      <div className="p-6 border-t border-gray-200 text-sm flex items-center space-x-3">
+        <img src="/favicon.ico" alt="User" className="w-8 h-8 rounded-full" />
+        <span className="flex-1">Demo User</span>
+        <button onClick={handleLogout} className="py-1 px-3 bg-red-500 text-white rounded">
+          Çıkış Yap
+        </button>
+      </div>
+    </aside>
+  );
+};
 
 export default Sidebar;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (typeof window !== "undefined") {
+      localStorage.setItem("isAuthenticated", "true");
+    }
+    router.push("/");
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded shadow-md space-y-4 w-80"
+      >
+        <h1 className="text-2xl font-bold text-center">Giriş Yap</h1>
+        <input
+          type="text"
+          placeholder="Kullanıcı Adı"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Şifre"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 rounded"
+        >
+          Giriş
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import ShoutingChart from "./components/ShoutingChart";
 import EmotionTopicBarChart from "./components/EmotionTopicBarChart";
 import EmotionsRadarChart from "./components/EmotionsRadarChart";
@@ -11,11 +12,19 @@ import Sidebar from "./components/Sidebar";
 
 // --- ANA DASHBOARD BILEŞENİ ---
 const App = () => {
+  const router = useRouter();
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
+    if (typeof window !== "undefined") {
+      const auth = localStorage.getItem("isAuthenticated");
+      if (auth !== "true") {
+        router.push("/login");
+        return;
+      }
+    }
     setIsClient(true);
-  }, []);
+  }, [router]);
 
   if (!isClient) return null;
 


### PR DESCRIPTION
## Summary
- add a basic login form saving `isAuthenticated` in `localStorage`
- redirect the dashboard to the login page if the user isn't authenticated
- enhance the sidebar with a meeting search/filter section and recent meetings list
- implement logout button using `localStorage`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cc2707d4083249cde3189424c0029